### PR TITLE
Change compiler package name

### DIFF
--- a/proteus-compiler-kotlin/settings.gradle.kts
+++ b/proteus-compiler-kotlin/settings.gradle.kts
@@ -1,3 +1,3 @@
 
-rootProject.name = "proteus-compiler-kotlin"
+rootProject.name = "proteus-compiler"
 


### PR DESCRIPTION
## Change compiler package name
- Changed package name from `proteus-compiler-kotlin` to `proteus-compiler`.