### PR TITLE
Add break & continue

### DIFF
--- a/proteus-compiler-kotlin/hello-world.psl
+++ b/proteus-compiler-kotlin/hello-world.psl
@@ -1,19 +1,17 @@
-val count = 1 * 900 ;
-
-fn recursive(n: Int) {
-    println(n);
-    if n == 0
-        println("Done")
-    else
-        recursive(n - 1);
+fn main() {
+    for x in 1 until 10 {
+        var i = -1;
+        if x == 5 {
+            continue;
+        }
+        while(i < 10) {
+            i = i + 1;
+            if i == 5 {
+                continue;
+            }
+            println(i);
+        }
+    }
 }
 
-fn test() {
-    if 1 == (2 - 1)
-        print("Hi")
-    else
-        val x = false and true;
-}
-
-test();
-recursive(count);
+main();

--- a/proteus-compiler-kotlin/hello-world.psl
+++ b/proteus-compiler-kotlin/hello-world.psl
@@ -1,4 +1,4 @@
-val count = 100;
+val count = 1 * 900 ;
 
 fn recursive(n: Int) {
     println(n);
@@ -8,4 +8,12 @@ fn recursive(n: Int) {
         recursive(n - 1);
 }
 
+fn test() {
+    if 1 == (2 - 1)
+        print("Hi")
+    else
+        val x = false and true;
+}
+
+test();
 recursive(count);

--- a/proteus-compiler-kotlin/hello-world.psl
+++ b/proteus-compiler-kotlin/hello-world.psl
@@ -1,6 +1,7 @@
 fn main() {
     for x in 1 until 10 {
         var i = -1;
+        println("x = " + x as String);
         if x == 5 {
             continue;
         }
@@ -9,7 +10,7 @@ fn main() {
             if i == 5 {
                 continue;
             }
-            println(i);
+            println("i = " + i as String);
         }
     }
 }

--- a/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/api/Compilation.kt
+++ b/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/api/Compilation.kt
@@ -8,7 +8,8 @@ import lang.proteus.binding.BoundGlobalScope
 import lang.proteus.evaluator.EvaluationResult
 import lang.proteus.evaluator.Evaluator
 import lang.proteus.generation.CodeGenerator
-import lang.proteus.lowering.Lowerer
+import lang.proteus.generation.Lowerer
+import lang.proteus.generation.Optimizer
 import lang.proteus.syntax.parser.SyntaxTree
 
 internal class Compilation internal constructor(val previous: Compilation?, val syntaxTree: SyntaxTree) {
@@ -62,7 +63,9 @@ internal class Compilation internal constructor(val previous: Compilation?, val 
     }
 
     private fun getStatement(): BoundBlockStatement {
-        return Lowerer.lower(globalScope.statement)
+        val lowered = Lowerer.lower(globalScope.statement)
+        val optimized = Optimizer.optimize(lowered)
+        return optimized
     }
 
 

--- a/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/binding/Binder.kt
+++ b/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/binding/Binder.kt
@@ -228,6 +228,7 @@ internal class Binder(private var scope: BoundScope, private val function: Funct
         scope.tryDeclareVariable(variable)
         controlStructureStack.push(Keyword.For)
         val body = bindStatement(syntax.body)
+        controlStructureStack.pop()
         scope = scope.parent!!
         return BoundForStatement(variable, boundLower, syntax.rangeOperator.token, boundUpper, body)
     }
@@ -236,7 +237,7 @@ internal class Binder(private var scope: BoundScope, private val function: Funct
         val condition = bindExpressionWithType(syntax.condition, TypeSymbol.Boolean)
         controlStructureStack.push(Keyword.While)
         val body = bindStatement(syntax.body)
-
+        controlStructureStack.pop()
         return BoundWhileStatement(condition, body)
     }
 
@@ -439,7 +440,7 @@ internal class Binder(private var scope: BoundScope, private val function: Funct
             return BoundErrorExpression
         }
         val convertedExpression = bindConversion(boundExpression, declaredVariable.type, syntax.expression.span())
-        return BoundAssignmentExpression(declaredVariable, convertedExpression, assignmentOperator)
+        return BoundAssignmentExpression(declaredVariable, convertedExpression, assignmentOperator, returnAssignment = true)
     }
 
     private fun bindNameExpressionSyntax(syntax: NameExpressionSyntax): BoundExpression {

--- a/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/binding/Binder.kt
+++ b/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/binding/Binder.kt
@@ -22,6 +22,9 @@ internal class Binder(private var scope: BoundScope, private val function: Funct
         }
     }
 
+    private val controlStructureStack: Stack<Keyword> = Stack()
+
+
     companion object {
         fun bindGlobalScope(previous: BoundGlobalScope?, syntax: CompilationUnitSyntax): BoundGlobalScope {
             val parentScope = createParentScopes(previous)
@@ -170,7 +173,35 @@ internal class Binder(private var scope: BoundScope, private val function: Funct
             is IfStatementSyntax -> bindIfStatement(syntax)
             is WhileStatementSyntax -> bindWhileStatement(syntax)
             is ForStatementSyntax -> bindForStatement(syntax)
+            is BreakStatementSyntax -> bindBreakStatement(syntax)
+            is ContinueStatementSyntax -> bindContinueStatement(syntax)
         }
+    }
+
+    private fun bindContinueStatement(syntax: ContinueStatementSyntax): BoundStatement {
+        val isInsideLoop = isInsideLoop()
+        if (!isInsideLoop) {
+            diagnosticsBag.reportContinueOutsideLoop(syntax.span())
+        }
+        return BoundContinueStatement()
+    }
+
+    private fun bindBreakStatement(syntax: BreakStatementSyntax): BoundStatement {
+        if(!isInsideLoop()) {
+            diagnosticsBag.reportBreakOutsideLoop(syntax.span())
+        }
+        return BoundBreakStatement()
+    }
+
+    private fun isInsideLoop(): Boolean {
+        var isInsideLoop = false
+        for (keyword in controlStructureStack) {
+            if (keyword == Keyword.While || keyword == Keyword.For) {
+                isInsideLoop = true
+                break
+            }
+        }
+        return isInsideLoop
     }
 
     private fun bindForStatement(syntax: ForStatementSyntax): BoundStatement {
@@ -195,6 +226,7 @@ internal class Binder(private var scope: BoundScope, private val function: Funct
         }
 
         scope.tryDeclareVariable(variable)
+        controlStructureStack.push(Keyword.For)
         val body = bindStatement(syntax.body)
         scope = scope.parent!!
         return BoundForStatement(variable, boundLower, syntax.rangeOperator.token, boundUpper, body)
@@ -202,9 +234,12 @@ internal class Binder(private var scope: BoundScope, private val function: Funct
 
     private fun bindWhileStatement(syntax: WhileStatementSyntax): BoundStatement {
         val condition = bindExpressionWithType(syntax.condition, TypeSymbol.Boolean)
+        controlStructureStack.push(Keyword.While)
         val body = bindStatement(syntax.body)
+
         return BoundWhileStatement(condition, body)
     }
+
 
     private fun bindIfStatement(syntax: IfStatementSyntax): BoundStatement {
         val condition = bindExpressionWithType(syntax.condition, TypeSymbol.Boolean)

--- a/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/binding/Binder.kt
+++ b/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/binding/Binder.kt
@@ -75,7 +75,7 @@ internal class Binder(private var scope: BoundScope, private val function: Funct
             return parent;
         }
 
-        fun bindProgram(globalScope: BoundGlobalScope): BoundProgram {
+        fun bindProgram(globalScope: BoundGlobalScope, optimize: Boolean = true): BoundProgram {
 
             val parentScope = createParentScopes(globalScope)
 
@@ -91,7 +91,7 @@ internal class Binder(private var scope: BoundScope, private val function: Funct
                 val body = binder.bindStatement(function.declaration!!.body)
                 if (!binder.hasErrors()) {
                     val loweredBody = Lowerer.lower(body)
-                    val optimizedBody = Optimizer.optimize(loweredBody)
+                    val optimizedBody = if (optimize) Optimizer.optimize(loweredBody) else loweredBody
                     functionBodies[function] = optimizedBody
                 }
                 diagnostics.addAll(binder.diagnostics)

--- a/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/binding/Binder.kt
+++ b/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/binding/Binder.kt
@@ -3,7 +3,8 @@ package lang.proteus.binding
 import lang.proteus.diagnostics.Diagnosable
 import lang.proteus.diagnostics.DiagnosticsBag
 import lang.proteus.diagnostics.TextSpan
-import lang.proteus.lowering.Lowerer
+import lang.proteus.generation.Lowerer
+import lang.proteus.generation.Optimizer
 import lang.proteus.symbols.*
 import lang.proteus.syntax.lexer.token.Keyword
 import lang.proteus.syntax.parser.*
@@ -90,7 +91,8 @@ internal class Binder(private var scope: BoundScope, private val function: Funct
                 val body = binder.bindStatement(function.declaration!!.body)
                 if (!binder.hasErrors()) {
                     val loweredBody = Lowerer.lower(body)
-                    functionBodies[function] = loweredBody
+                    val optimizedBody = Optimizer.optimize(loweredBody)
+                    functionBodies[function] = optimizedBody
                 }
                 diagnostics.addAll(binder.diagnostics)
             }

--- a/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/binding/BoundAssignmentExpression.kt
+++ b/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/binding/BoundAssignmentExpression.kt
@@ -8,6 +8,7 @@ internal class BoundAssignmentExpression(
     val variable: VariableSymbol,
     val expression: BoundExpression,
     val assignmentOperator: AssignmentOperator,
+    val returnAssignment: Boolean ,
 ) : BoundExpression() {
     override val type: TypeSymbol
         get() = expression.type

--- a/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/binding/BoundBreakStatement.kt
+++ b/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/binding/BoundBreakStatement.kt
@@ -1,0 +1,5 @@
+package lang.proteus.binding
+
+internal class BoundBreakStatement: BoundStatement() {
+
+}

--- a/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/binding/BoundConditionalGotoStatement.kt
+++ b/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/binding/BoundConditionalGotoStatement.kt
@@ -3,5 +3,5 @@ package lang.proteus.binding
 internal data class BoundConditionalGotoStatement(
     val condition: BoundExpression,
     val label: BoundLabel,
-    val jumpIfFalse: Boolean = false,
+    val jumpIfFalse: Boolean ,
 ) : BoundStatement()

--- a/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/binding/BoundContinueStatement.kt
+++ b/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/binding/BoundContinueStatement.kt
@@ -1,0 +1,4 @@
+package lang.proteus.binding
+
+internal class BoundContinueStatement: BoundStatement() {
+}

--- a/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/binding/BoundForStatement.kt
+++ b/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/binding/BoundForStatement.kt
@@ -1,10 +1,11 @@
 package lang.proteus.binding
 
+import lang.proteus.symbols.LocalVariableSymbol
 import lang.proteus.symbols.VariableSymbol
 import lang.proteus.syntax.lexer.token.Keyword
 
 internal data class BoundForStatement(
-    val variable: VariableSymbol,
+    val variable: LocalVariableSymbol,
     val lowerBound: BoundExpression,
     val rangeOperator: Keyword,
     val upperBound: BoundExpression,

--- a/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/binding/BoundNopStatement.kt
+++ b/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/binding/BoundNopStatement.kt
@@ -1,0 +1,4 @@
+package lang.proteus.binding
+
+internal class BoundNopStatement : BoundStatement() {
+}

--- a/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/binding/BoundTreeRewriter.kt
+++ b/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/binding/BoundTreeRewriter.kt
@@ -45,7 +45,7 @@ internal abstract class BoundTreeRewriter {
         if (condition == statement.condition) {
             return statement
         }
-        return BoundConditionalGotoStatement(condition, statement.label)
+        return BoundConditionalGotoStatement(condition, statement.label, statement.jumpIfFalse)
     }
 
     protected open fun rewriteWhileStatement(node: BoundWhileStatement): BoundStatement {
@@ -172,7 +172,7 @@ internal abstract class BoundTreeRewriter {
         val expression = rewriteExpression(node.expression)
         if (expression == node.expression)
             return node
-        return BoundAssignmentExpression(node.variable, expression, node.assignmentOperator)
+        return BoundAssignmentExpression(node.variable, expression, node.assignmentOperator, node.returnAssignment)
     }
 
 }

--- a/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/binding/BoundTreeRewriter.kt
+++ b/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/binding/BoundTreeRewriter.kt
@@ -13,7 +13,12 @@ internal abstract class BoundTreeRewriter {
             is BoundConditionalGotoStatement -> rewriteConditionalGotoStatement(statement)
             is BoundGotoStatement -> rewriteGotoStatement(statement)
             is BoundLabelStatement -> rewriteLabelStatement(statement)
+            is BoundNopStatement -> rewriteNopStatement(statement)
         }
+    }
+
+    protected open fun rewriteNopStatement(statement: BoundNopStatement): BoundStatement {
+        return statement
     }
 
     protected open fun rewriteLabelStatement(statement: BoundLabelStatement): BoundStatement {

--- a/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/binding/BoundTreeRewriter.kt
+++ b/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/binding/BoundTreeRewriter.kt
@@ -14,8 +14,19 @@ internal abstract class BoundTreeRewriter {
             is BoundGotoStatement -> rewriteGotoStatement(statement)
             is BoundLabelStatement -> rewriteLabelStatement(statement)
             is BoundNopStatement -> rewriteNopStatement(statement)
+            is BoundBreakStatement -> rewriteBreakStatement(statement)
+            is BoundContinueStatement -> rewriteContinueStatement(statement)
         }
     }
+
+    protected open fun rewriteContinueStatement(statement: BoundContinueStatement): BoundStatement {
+        return statement
+    }
+
+    protected open fun rewriteBreakStatement(statement: BoundBreakStatement): BoundStatement {
+        return statement
+    }
+
 
     protected open fun rewriteNopStatement(statement: BoundNopStatement): BoundStatement {
         return statement

--- a/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/diagnostics/DiagnosticsBag.kt
+++ b/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/diagnostics/DiagnosticsBag.kt
@@ -132,4 +132,12 @@ internal class DiagnosticsBag {
         report("Expected a global statement", TextSpan(0, 0))
     }
 
+    fun reportContinueOutsideLoop(span: TextSpan) {
+        report("Continue statement must be inside a loop", span)
+    }
+
+    fun reportBreakOutsideLoop(span: TextSpan) {
+        report("Break statement must be inside a loop", span)
+    }
+
 }

--- a/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/evaluator/BinaryExpressionEvaluator.kt
+++ b/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/evaluator/BinaryExpressionEvaluator.kt
@@ -1,0 +1,45 @@
+package lang.proteus.evaluator
+
+import lang.proteus.binding.BoundBinaryOperatorKind
+import lang.proteus.symbols.TypeSymbol
+import kotlin.math.pow
+
+internal object BinaryExpressionEvaluator {
+    fun evaluate(kind: BoundBinaryOperatorKind, resultType: TypeSymbol, left: Any, right: Any): Any {
+        return when (kind) {
+            BoundBinaryOperatorKind.Addition -> {
+                if (resultType == TypeSymbol.Int) {
+                    (left as Int) + (right as Int)
+                } else {
+                    (left as String) + (right as String)
+                }
+            }
+
+            BoundBinaryOperatorKind.Subtraction -> left as Int - right as Int
+            BoundBinaryOperatorKind.Division -> left as Int / right as Int
+            BoundBinaryOperatorKind.Multiplication -> left as Int * right as Int
+            BoundBinaryOperatorKind.Exponentiation -> (left as Int).toDouble().pow(right as Int).toInt()
+            BoundBinaryOperatorKind.Modulo -> left as Int % right as Int
+            BoundBinaryOperatorKind.BitwiseAnd -> left as Int and right as Int
+            BoundBinaryOperatorKind.BitwiseXor -> left as Int xor right as Int
+            BoundBinaryOperatorKind.BitwiseOr -> left as Int or right as Int
+            BoundBinaryOperatorKind.LogicalAnd -> left as Boolean and right as Boolean
+            BoundBinaryOperatorKind.LogicalOr -> left as Boolean or right as Boolean
+            BoundBinaryOperatorKind.LogicalXor -> left as Boolean xor right as Boolean
+            BoundBinaryOperatorKind.Equality -> left == right
+            BoundBinaryOperatorKind.Inequality -> left != right
+            BoundBinaryOperatorKind.GreaterThan -> left as Int > right as Int
+            BoundBinaryOperatorKind.GreaterThanOrEqual -> left as Int >= right as Int
+            BoundBinaryOperatorKind.LessThan -> (left as Int) < (right as Int)
+            BoundBinaryOperatorKind.LessThanOrEqual -> left as Int <= right as Int
+            BoundBinaryOperatorKind.BitwiseShiftLeft -> left as Int shl right as Int
+            BoundBinaryOperatorKind.BitwiseShiftRight -> left as Int shr right as Int
+            BoundBinaryOperatorKind.TypeEquality -> (right as TypeSymbol).isAssignableTo(
+                TypeSymbol.fromValueOrAny(
+                    left
+                )
+            )
+
+        }
+    }
+}

--- a/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/evaluator/BinaryExpressionEvaluator.kt
+++ b/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/evaluator/BinaryExpressionEvaluator.kt
@@ -6,7 +6,7 @@ import kotlin.math.pow
 
 internal object BinaryExpressionEvaluator {
     fun evaluate(kind: BoundBinaryOperatorKind, resultType: TypeSymbol, left: Any, right: Any): Any {
-        return when (kind) {
+        val result =  when (kind) {
             BoundBinaryOperatorKind.Addition -> {
                 if (resultType == TypeSymbol.Int) {
                     (left as Int) + (right as Int)
@@ -41,5 +41,6 @@ internal object BinaryExpressionEvaluator {
             )
 
         }
+        return result
     }
 }

--- a/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/evaluator/Evaluator.kt
+++ b/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/evaluator/Evaluator.kt
@@ -69,6 +69,10 @@ internal class Evaluator(
                 currentIndex + 1
             }
 
+            is BoundNopStatement -> {
+                currentIndex + 1
+            }
+
             else -> {
                 throwUnsupportedOperation(statement::class.simpleName!!)
             }

--- a/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/evaluator/Evaluator.kt
+++ b/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/evaluator/Evaluator.kt
@@ -5,7 +5,6 @@ import lang.proteus.symbols.FunctionSymbol
 import lang.proteus.symbols.ProteusExternalFunction
 import lang.proteus.symbols.TypeSymbol
 import java.util.*
-import kotlin.math.pow
 
 internal class Evaluator(
     private val root: BoundBlockStatement,
@@ -162,7 +161,7 @@ internal class Evaluator(
 
     private fun evaluateVariableExpression(expression: BoundVariableExpression): Any {
         if (expression.variable.isLocal) {
-            if(locals.isEmpty()) throw IllegalStateException("No locals found for ${expression.variable.name}")
+            if (locals.isEmpty()) throw IllegalStateException("No locals found for ${expression.variable.name}")
             return locals.peek()[expression.variable.name]!!
         }
         return globals[expression.variable.name]!!
@@ -184,53 +183,14 @@ internal class Evaluator(
         val right = evaluateExpression(expression.right)
 
 
-        return when (expression.operator.kind) {
-            BoundBinaryOperatorKind.Addition -> {
-                if (expression.type == TypeSymbol.Int) {
-                    (left as Int) + (right as Int)
-                } else {
-                    (left as String) + (right as String)
-                }
-            }
-
-            BoundBinaryOperatorKind.Subtraction -> left as Int - right as Int
-            BoundBinaryOperatorKind.Division -> left as Int / right as Int
-            BoundBinaryOperatorKind.Multiplication -> left as Int * right as Int
-            BoundBinaryOperatorKind.Exponentiation -> (left as Int).toDouble().pow(right as Int).toInt()
-            BoundBinaryOperatorKind.Modulo -> left as Int % right as Int
-            BoundBinaryOperatorKind.BitwiseAnd -> left as Int and right as Int
-            BoundBinaryOperatorKind.BitwiseXor -> left as Int xor right as Int
-            BoundBinaryOperatorKind.BitwiseOr -> left as Int or right as Int
-            BoundBinaryOperatorKind.LogicalAnd -> left as Boolean and right as Boolean
-            BoundBinaryOperatorKind.LogicalOr -> left as Boolean or right as Boolean
-            BoundBinaryOperatorKind.LogicalXor -> left as Boolean xor right as Boolean
-            BoundBinaryOperatorKind.Equality -> left == right
-            BoundBinaryOperatorKind.Inequality -> left != right
-            BoundBinaryOperatorKind.GreaterThan -> left as Int > right as Int
-            BoundBinaryOperatorKind.GreaterThanOrEqual -> left as Int >= right as Int
-            BoundBinaryOperatorKind.LessThan -> (left as Int) < (right as Int)
-            BoundBinaryOperatorKind.LessThanOrEqual -> left as Int <= right as Int
-            BoundBinaryOperatorKind.BitwiseShiftLeft -> left as Int shl right as Int
-            BoundBinaryOperatorKind.BitwiseShiftRight -> left as Int shr right as Int
-            BoundBinaryOperatorKind.TypeEquality -> (right as TypeSymbol).isAssignableTo(
-                TypeSymbol.fromValueOrAny(
-                    left
-                )
-            )
-
-        }
+        return BinaryExpressionEvaluator.evaluate(expression.operator.kind, expression.type, left!!, right!!)
 
     }
 
 
     private fun evaluateUnaryExpression(expression: BoundUnaryExpression): Any {
         val operand = evaluateExpression(expression.operand)
-        return when (expression.operator) {
-            BoundUnaryOperator.BoundUnaryIdentityOperator -> operand as Int
-            BoundUnaryOperator.BoundUnaryNegationOperator -> -(operand as Int)
-            BoundUnaryOperator.BoundUnaryNotOperator -> !(operand as Boolean)
-            BoundUnaryOperator.BoundUnaryTypeOfOperator -> TypeSymbol.fromValueOrAny(operand)
-        }
+        return UnaryExpressionEvaluator.evaluate(expression.operator, operand!!)
     }
 
 

--- a/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/evaluator/Evaluator.kt
+++ b/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/evaluator/Evaluator.kt
@@ -172,6 +172,11 @@ internal class Evaluator(
     }
 
     private fun evaluateAssignmentExpression(expression: BoundAssignmentExpression): Any {
+        val currentValue = if (expression.variable.isLocal) {
+            locals.peek()[expression.variable.name]!!
+        } else {
+            globals[expression.variable.name]!!
+        }
         val expressionValue = evaluateExpression(expression.expression)
         if (expression.variable.isGlobal) {
             globals[expression.variable.name] = expressionValue!!
@@ -179,7 +184,7 @@ internal class Evaluator(
             locals.peek()[expression.variable.name] = expressionValue!!
         }
 
-        return expressionValue
+        return if (expression.returnAssignment) expressionValue else currentValue
     }
 
     private fun evaluateBinaryExpression(expression: BoundBinaryExpression): Any {

--- a/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/evaluator/UnaryExpressionEvaluator.kt
+++ b/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/evaluator/UnaryExpressionEvaluator.kt
@@ -1,0 +1,15 @@
+package lang.proteus.evaluator
+
+import lang.proteus.binding.BoundUnaryOperator
+import lang.proteus.symbols.TypeSymbol
+
+internal object  UnaryExpressionEvaluator {
+    fun evaluate(operator:  BoundUnaryOperator, operand: Any): Any {
+        return when (operator) {
+            BoundUnaryOperator.BoundUnaryIdentityOperator -> operand as Int
+            BoundUnaryOperator.BoundUnaryNegationOperator -> -(operand as Int)
+            BoundUnaryOperator.BoundUnaryNotOperator -> !(operand as Boolean)
+            BoundUnaryOperator.BoundUnaryTypeOfOperator -> TypeSymbol.fromValueOrAny(operand)
+        }
+    }
+}

--- a/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/generation/CodeGenerator.kt
+++ b/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/generation/CodeGenerator.kt
@@ -60,11 +60,13 @@ internal class CodeGenerator private constructor(
 
     override fun rewriteBinaryExpression(node: BoundBinaryExpression): BoundExpression {
         codeBuilder.append("(")
+        codeBuilder.append("(")
         rewriteExpression(node.left)
-        codeBuilder.append(" ")
+        codeBuilder.append(") ")
         codeBuilder.append(node.operator.operator.literal)
-        codeBuilder.append(" ")
+        codeBuilder.append(" (")
         rewriteExpression(node.right)
+        codeBuilder.append(")")
         codeBuilder.append(")")
         return node
     }
@@ -134,7 +136,9 @@ internal class CodeGenerator private constructor(
 
     override fun rewriteUnaryExpression(node: BoundUnaryExpression): BoundExpression {
         codeBuilder.append(node.operator.operator.literal)
+        codeBuilder.append("(")
         rewriteExpression(node.operand)
+        codeBuilder.append(")")
         return node
     }
 

--- a/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/generation/CodeGenerator.kt
+++ b/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/generation/CodeGenerator.kt
@@ -2,6 +2,7 @@ package lang.proteus.generation
 
 import lang.proteus.binding.*
 import lang.proteus.symbols.FunctionSymbol
+import lang.proteus.symbols.TypeSymbol
 import java.io.File
 import java.time.Instant
 
@@ -122,7 +123,12 @@ internal class CodeGenerator private constructor(
     }
 
     override fun rewriteLiteralExpression(expression: BoundLiteralExpression<*>): BoundExpression {
-        codeBuilder.append(expression.value)
+        val value =
+        when (expression.type) {
+            is TypeSymbol.String -> "\"${expression.value}\""
+            else -> expression.value
+        }
+        codeBuilder.append(value)
         return expression
     }
 
@@ -157,4 +163,5 @@ internal class CodeGenerator private constructor(
         codeBuilder.append(";")
         return statement
     }
+
 }

--- a/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/generation/CodeGenerator.kt
+++ b/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/generation/CodeGenerator.kt
@@ -116,6 +116,11 @@ internal class CodeGenerator private constructor(
         return statement
     }
 
+    override fun rewriteNopStatement(statement: BoundNopStatement): BoundStatement {
+        codeBuilder.append("nop;")
+        return statement
+    }
+
     override fun rewriteLiteralExpression(expression: BoundLiteralExpression<*>): BoundExpression {
         codeBuilder.append(expression.value)
         return expression

--- a/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/generation/Lowerer.kt
+++ b/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/generation/Lowerer.kt
@@ -1,4 +1,4 @@
-package lang.proteus.lowering
+package lang.proteus.generation
 
 import lang.proteus.binding.*
 import lang.proteus.syntax.lexer.token.Operator

--- a/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/generation/Optimizer.kt
+++ b/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/generation/Optimizer.kt
@@ -39,9 +39,6 @@ internal class Optimizer private constructor() : BoundTreeRewriter() {
 
     override fun rewriteVariableDeclaration(node: BoundVariableDeclaration): BoundStatement {
         val initializer = rewriteExpression(node.initializer)
-        if (initializer is BoundLiteralExpression<*>) {
-            return BoundExpressionStatement(BoundAssignmentExpression(node.variable, initializer, Operator.Equals))
-        }
         if (initializer == node.initializer) {
             return node
         }
@@ -61,7 +58,7 @@ internal class Optimizer private constructor() : BoundTreeRewriter() {
         if (expression == node.expression) {
             return node
         }
-        return BoundAssignmentExpression(node.variable, expression, node.assignmentOperator)
+        return BoundAssignmentExpression(node.variable, expression, node.assignmentOperator, node.returnAssignment)
     }
 
     override fun rewriteBinaryExpression(node: BoundBinaryExpression): BoundExpression {

--- a/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/generation/Optimizer.kt
+++ b/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/generation/Optimizer.kt
@@ -1,0 +1,104 @@
+package lang.proteus.generation
+
+import lang.proteus.binding.*
+import lang.proteus.evaluator.BinaryExpressionEvaluator
+import lang.proteus.evaluator.UnaryExpressionEvaluator
+import lang.proteus.syntax.lexer.token.Operator
+
+internal class Optimizer private constructor() : BoundTreeRewriter() {
+    companion object {
+        fun optimize(statement: BoundBlockStatement): BoundBlockStatement {
+            val optimizer = Optimizer()
+            return optimizer.rewriteBlockStatement(statement)
+        }
+    }
+
+    override fun rewriteConditionalGotoStatement(statement: BoundConditionalGotoStatement): BoundStatement {
+        val condition = rewriteExpression(statement.condition)
+        if (condition is BoundLiteralExpression<*>) {
+            val value = condition.value as Boolean
+            if (statement.jumpIfFalse == value) {
+                return BoundNopStatement()
+            }
+            return BoundGotoStatement(statement.label)
+        }
+        return statement
+    }
+
+    override fun rewriteUnaryExpression(node: BoundUnaryExpression): BoundExpression {
+        val operand = rewriteExpression(node.operand)
+        if (operand is BoundLiteralExpression<*>) {
+            val value = UnaryExpressionEvaluator.evaluate(node.operator, operand.value)
+            return BoundLiteralExpression(value)
+        }
+        if (operand == node.operand) {
+            return node
+        }
+        return BoundUnaryExpression(operand, node.operator)
+    }
+
+    override fun rewriteVariableDeclaration(node: BoundVariableDeclaration): BoundStatement {
+        val initializer = rewriteExpression(node.initializer)
+        if (initializer is BoundLiteralExpression<*>) {
+            return BoundExpressionStatement(BoundAssignmentExpression(node.variable, initializer, Operator.Equals))
+        }
+        if (initializer == node.initializer) {
+            return node
+        }
+        return BoundVariableDeclaration(node.variable, initializer)
+    }
+
+    override fun rewriteCallExpression(expression: BoundCallExpression): BoundExpression {
+        val arguments = expression.arguments.map { rewriteExpression(it) }
+        if (arguments == expression.arguments) {
+            return expression
+        }
+        return BoundCallExpression(expression.functionSymbol, arguments, expression.isExternal)
+    }
+
+    override fun rewriteAssignmentExpression(node: BoundAssignmentExpression): BoundExpression {
+        val expression = rewriteExpression(node.expression)
+        if (expression == node.expression) {
+            return node
+        }
+        return BoundAssignmentExpression(node.variable, expression, node.assignmentOperator)
+    }
+
+    override fun rewriteBinaryExpression(node: BoundBinaryExpression): BoundExpression {
+        val left = rewriteExpression(node.left)
+        val right = rewriteExpression(node.right)
+        if (left is BoundLiteralExpression<*> && right is BoundLiteralExpression<*>) {
+            val value = BinaryExpressionEvaluator.evaluate(node.operator.kind, node.type, left.value, right.value)
+            return BoundLiteralExpression(value)
+        }
+        if (left == node.left && right == node.right) {
+            return node
+        }
+        return BoundBinaryExpression(left, right, node.operator)
+    }
+
+    override fun rewriteBlockStatement(node: BoundBlockStatement): BoundBlockStatement {
+        val statements = node.statements.map { rewriteStatement(it) }
+        if (statements == node.statements) {
+            return node
+        }
+        return BoundBlockStatement(statements)
+    }
+
+    override fun rewriteConversionExpression(expression: BoundConversionExpression): BoundExpression {
+        val rewrittenExpression = rewriteExpression(expression.expression)
+        if (rewrittenExpression == expression) {
+            return expression
+        }
+        return BoundConversionExpression(expression.type, expression, expression.conversion)
+    }
+
+    override fun rewriteExpressionStatement(statement: BoundExpressionStatement): BoundStatement {
+        val rewrittenExpression = rewriteExpression(statement.expression)
+        if (rewrittenExpression == statement.expression) {
+            return statement
+        }
+        return BoundExpressionStatement(rewrittenExpression)
+    }
+
+}

--- a/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/syntax/lexer/token/Keyword.kt
+++ b/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/syntax/lexer/token/Keyword.kt
@@ -40,5 +40,7 @@ internal sealed class Keyword(override val literal: kotlin.String) : Token() {
 
     internal object Until : Keyword("until")
     internal object Fn : Keyword("fn")
+    internal object Break : Keyword("break")
+    internal object Continue : Keyword("continue")
 }
 

--- a/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/syntax/parser/Parser.kt
+++ b/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/syntax/parser/Parser.kt
@@ -45,7 +45,7 @@ class Parser private constructor(
 
     internal fun parseCompilationUnit(): CompilationUnitSyntax {
         val members = parseMembers()
-        if(members.isEmpty()){
+        if (members.isEmpty()) {
             diagnosticsBag.reportExpectedGlobalStatement()
         }
         val endOfFileToken = matchToken(Token.EndOfFile)
@@ -164,8 +164,26 @@ class Parser private constructor(
                 return parseForStatement()
             }
 
+            is Keyword.Continue -> {
+                return parseContinueStatement()
+            }
+
+            is Keyword.Break -> {
+                return parseBreakStatement()
+            }
+
             else -> return parseExpressionStatement()
         }
+    }
+
+    private fun parseBreakStatement(): StatementSyntax {
+        val breakKeyword = matchToken(Keyword.Break)
+        return BreakStatementSyntax(breakKeyword)
+    }
+
+    private fun parseContinueStatement(): StatementSyntax {
+        val continueKeyword = matchToken(Keyword.Continue)
+        return ContinueStatementSyntax(continueKeyword)
     }
 
     private fun parseForStatement(): StatementSyntax {

--- a/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/syntax/parser/statements/BreakStatementSyntax.kt
+++ b/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/syntax/parser/statements/BreakStatementSyntax.kt
@@ -1,0 +1,11 @@
+package lang.proteus.syntax.parser.statements
+
+import lang.proteus.syntax.lexer.SyntaxToken
+import lang.proteus.syntax.lexer.token.Keyword
+import lang.proteus.syntax.lexer.token.Token
+
+internal data class BreakStatementSyntax(
+    val breakToken: SyntaxToken<Keyword.Break>,
+) : StatementSyntax() {
+}
+

--- a/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/syntax/parser/statements/ContinueStatementSyntax.kt
+++ b/proteus-compiler-kotlin/src/main/kotlin/lang/proteus/syntax/parser/statements/ContinueStatementSyntax.kt
@@ -1,0 +1,10 @@
+package lang.proteus.syntax.parser.statements
+
+import lang.proteus.syntax.lexer.SyntaxToken
+import lang.proteus.syntax.lexer.token.Keyword
+import lang.proteus.syntax.lexer.token.Token
+
+internal data class ContinueStatementSyntax(
+    val continueKeyword: SyntaxToken<Keyword.Continue>,
+) : StatementSyntax() {
+}

--- a/proteus-compiler-kotlin/src/test/kotlin/lang/proteus/evaluation/EvaluationTest.kt
+++ b/proteus-compiler-kotlin/src/test/kotlin/lang/proteus/evaluation/EvaluationTest.kt
@@ -395,6 +395,29 @@ class EvaluationTest {
                         hello + " " + number as String;
                     """.trimIndent(), "Hello 2"
                 ),
+
+                Arguments.of("""
+                    var a = 1;
+                    while true {
+                        if a == 10 {
+                            break;
+                        }
+                        a += 1;
+                    }
+                """.trimIndent(), 10),
+
+                Arguments.of("""
+                    var a = 0;
+                    var b = 0;
+                    while true {
+                        if a == 10 break;
+                        a += 1;
+                        if a == 2 {
+                           continue;
+                        }
+                        b += a;
+                    }
+                """.trimIndent(), 53),
             )
         }
     }

--- a/proteus-compiler-kotlin/src/test/kotlin/lang/proteus/evaluation/EvaluationTest.kt
+++ b/proteus-compiler-kotlin/src/test/kotlin/lang/proteus/evaluation/EvaluationTest.kt
@@ -354,7 +354,47 @@ class EvaluationTest {
                             random(random as Int, 1);
                         }
                     """.trimIndent(), 1
-                )
+                ),
+
+                Arguments.of(
+                    """
+                        "test" == "test";
+                    """.trimIndent(), true
+                ),
+                Arguments.of(
+                    """
+                        "test" == "tewest";
+                    """.trimIndent(), false
+                ),
+                Arguments.of(
+                    """
+                        "test" != "test";
+                    """.trimIndent(), false
+                ),
+                Arguments.of(
+                    """
+                        "test" != "teest";
+                    """.trimIndent(), true
+                ),
+                Arguments.of(
+                    """
+                        "test" + "test";
+                    """.trimIndent(), "testtest"
+                ),
+                Arguments.of(
+                    """
+                        val hello = "Hello";
+                        val name = "World";
+                        hello + " " + name;
+                    """.trimIndent(), "Hello World"
+                ),
+                Arguments.of(
+                    """
+                        val hello = "Hello";
+                        val number = 2;
+                        hello + " " + number as String;
+                    """.trimIndent(), "Hello 2"
+                ),
             )
         }
     }

--- a/proteus-compiler-kotlin/src/test/kotlin/lang/proteus/generation/CodeGenerationTest.kt
+++ b/proteus-compiler-kotlin/src/test/kotlin/lang/proteus/generation/CodeGenerationTest.kt
@@ -59,7 +59,7 @@ class CodeGenerationTest {
                         fn main() -> Unit {
                             var a = 1;
                             var b = 2;
-                            var c = (a + b);
+                            var c = ((a) + (b));
                         }
                         {
                             main();
@@ -97,14 +97,14 @@ class CodeGenerationTest {
                     """.trimIndent(),
                     """
                         fn main() -> Unit {
-                            gotoIfFalse label0 true;
+                            gotoIfFalse else_0 true;
                             var a = 1;
                             var b = 2;
-                            var c = (a + b);
-                            goto label1;
-                            label0:
+                            var c = ((a) + (b));
+                            goto if_0_end;
+                            else_0:
                             var a = 1;
-                            label1:
+                            if_0_end:
                         }
                         {
                         }

--- a/proteus-compiler-kotlin/src/test/kotlin/lang/proteus/generation/CodeGenerationTest.kt
+++ b/proteus-compiler-kotlin/src/test/kotlin/lang/proteus/generation/CodeGenerationTest.kt
@@ -1,6 +1,6 @@
 package lang.proteus.generation
 
-import lang.proteus.api.Compilation
+import lang.proteus.binding.Binder
 import lang.proteus.syntax.parser.SyntaxTree
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -11,9 +11,9 @@ import kotlin.test.assertEquals
 class CodeGenerationTest {
     private fun useProgram(input: String): String {
         val parsed = SyntaxTree.parse(input)
-        val compilation = Compilation(parsed)
-        val code = compilation.evaluate(mutableMapOf()).generatedCode
-        return code!!
+        val globalScope = Binder.bindGlobalScope(null, parsed.root)
+        val program = Binder.bindProgram(globalScope, optimize = false)
+        return CodeGenerator.generate(program.globalScope.statement, program.functionBodies)
     }
 
     @ParameterizedTest
@@ -63,6 +63,21 @@ class CodeGenerationTest {
                         }
                         {
                             main();
+                        }
+                        
+                    """.trimIndent()
+                ),
+                Arguments.of(
+                    """
+                        fn main() {
+                            val test = "test";
+                        }
+                    """.trimIndent(),
+                    """
+                        fn main() -> Unit {
+                            var test = "test";
+                        }
+                        {
                         }
                         
                     """.trimIndent()

--- a/proteus-compiler-kotlin/src/test/kotlin/lang/proteus/syntax/lexer/LexerTest.kt
+++ b/proteus-compiler-kotlin/src/test/kotlin/lang/proteus/syntax/lexer/LexerTest.kt
@@ -240,6 +240,9 @@ internal class LexerTest {
                 Arguments.of(Token.Arrow, "->"),
                 Arguments.of(Keyword.Fn, "fn"),
 
+                Arguments.of(Keyword.Break, "break"),
+                Arguments.of(Keyword.Continue, "continue"),
+
                 )
         }
 


### PR DESCRIPTION
## Add break & continue

Break & continue are both basic ways to control the flow of loops.
You can use `break` & `continue` in `while` and `for` loops.
### Break
```
fn main() {
    var a = 1;
    while true {
        a+= 1;
        if a == 10 break;
    }
}
```
`a` will be `10` after this loop.

### Continue
```
fn main() {
    var a = 1;
    for x in 1 until 10 {
       if x == 2 continue;
       a += x;   
 }
}
```
`a` will be `53` after this loop.

### Additional tests
#### String tests
- Added tests for string concatination & comparison